### PR TITLE
Add directives to mdast node type registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 coverage/
 node_modules/
 .DS_Store
-*.d.ts
+index.d.ts
+test.d.ts
 *.log
 yarn.lock

--- a/complex-types.d.ts
+++ b/complex-types.d.ts
@@ -1,0 +1,35 @@
+import type {Parent} from 'unist'
+import type {PhrasingContent, BlockContent} from 'mdast'
+
+type DirectiveAttributes = Record<string, string>
+
+interface DirectiveFields {
+  name: string
+  attributes?: DirectiveAttributes
+}
+
+export interface TextDirective extends Parent, DirectiveFields {
+  type: 'textDirective'
+  children: PhrasingContent[]
+}
+
+export interface LeafDirective extends Parent, DirectiveFields {
+  type: 'leafDirective'
+  children: PhrasingContent[]
+}
+
+export interface ContainerDirective extends Parent, DirectiveFields {
+  type: 'containerDirective'
+  children: BlockContent[]
+}
+
+declare module 'mdast' {
+  interface StaticPhrasingContentMap {
+    textDirective: TextDirective
+  }
+
+  interface BlockContentMap {
+    containerDirective: ContainerDirective
+    leafDirective: LeafDirective
+  }
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "files": [
+    "complex-types.d.ts",
     "index.d.ts",
     "index.js"
   ],
@@ -57,7 +58,7 @@
     "xo": "^0.39.0"
   },
   "scripts": {
-    "build": "rimraf \"*.d.ts\" && tsc && type-coverage",
+    "build": "rimraf \"{index,test}.d.ts\" && tsc && type-coverage",
     "format": "remark . -qfo && prettier . -w --loglevel warn && xo --fix",
     "test-api": "node --conditions development test.js",
     "test-coverage": "c8 --check-coverage --branches 100 --functions 100 --lines 100 --statements 100 --reporter lcov node --conditions development test.js",

--- a/test.js
+++ b/test.js
@@ -275,6 +275,7 @@ test('mdast -> markdown', (t) => {
         type: 'paragraph',
         children: [
           {type: 'text', value: 'a '},
+          // @ts-expect-error: `children`, `name` missing.
           {type: 'textDirective'},
           {type: 'text', value: ' b.'}
         ]
@@ -291,6 +292,7 @@ test('mdast -> markdown', (t) => {
         type: 'paragraph',
         children: [
           {type: 'text', value: 'a '},
+          // @ts-expect-error: `children` missing.
           {type: 'textDirective', name: 'b'},
           {type: 'text', value: ' c.'}
         ]
@@ -370,6 +372,7 @@ test('mdast -> markdown', (t) => {
           {
             type: 'textDirective',
             name: 'b',
+            // @ts-expect-error: should contain only `string`s
             attributes: {c: 'd', e: 'f', g: '', h: null, i: undefined, j: 2},
             children: []
           },
@@ -509,6 +512,7 @@ test('mdast -> markdown', (t) => {
   )
 
   t.deepEqual(
+    // @ts-expect-error: `children`, `name` missing.
     toMarkdown({type: 'leafDirective'}, {extensions: [directiveToMarkdown]}),
     '::\n',
     'should try to serialize a directive (leaf) w/o `name`'
@@ -516,6 +520,7 @@ test('mdast -> markdown', (t) => {
 
   t.deepEqual(
     toMarkdown(
+      // @ts-expect-error: `children` missing.
       {type: 'leafDirective', name: 'a'},
       {extensions: [directiveToMarkdown]}
     ),
@@ -567,7 +572,8 @@ test('mdast -> markdown', (t) => {
       {
         type: 'leafDirective',
         name: 'a',
-        attributes: {id: 'b', class: 'c d', key: 'e\nf'}
+        attributes: {id: 'b', class: 'c d', key: 'e\nf'},
+        children: []
       },
       {extensions: [directiveToMarkdown]}
     ),
@@ -577,6 +583,7 @@ test('mdast -> markdown', (t) => {
 
   t.deepEqual(
     toMarkdown(
+      // @ts-expect-error: `children`, `name` missing.
       {type: 'containerDirective'},
       {extensions: [directiveToMarkdown]}
     ),
@@ -586,6 +593,7 @@ test('mdast -> markdown', (t) => {
 
   t.deepEqual(
     toMarkdown(
+      // @ts-expect-error: `children` missing.
       {type: 'containerDirective', name: 'a'},
       {extensions: [directiveToMarkdown]}
     ),
@@ -611,7 +619,9 @@ test('mdast -> markdown', (t) => {
       {
         type: 'containerDirective',
         name: 'a',
-        children: [{type: 'heading', children: [{type: 'text', value: 'b'}]}]
+        children: [
+          {type: 'heading', depth: 1, children: [{type: 'text', value: 'b'}]}
+        ]
       },
       {extensions: [directiveToMarkdown]}
     ),
@@ -624,7 +634,9 @@ test('mdast -> markdown', (t) => {
       {
         type: 'containerDirective',
         name: 'a',
-        children: [{type: 'text', value: 'b\nc'}]
+        children: [
+          {type: 'paragraph', children: [{type: 'text', value: 'b\nc'}]}
+        ]
       },
       {extensions: [directiveToMarkdown]}
     ),
@@ -637,7 +649,8 @@ test('mdast -> markdown', (t) => {
       {
         type: 'containerDirective',
         name: 'a',
-        attributes: {id: 'b', class: 'c d', key: 'e\nf'}
+        attributes: {id: 'b', class: 'c d', key: 'e\nf'},
+        children: []
       },
       {extensions: [directiveToMarkdown]}
     ),
@@ -882,7 +895,7 @@ test('mdast -> markdown', (t) => {
       {
         type: 'paragraph',
         children: [
-          {type: 'textDirective', name: 'red'},
+          {type: 'textDirective', name: 'red', children: []},
           {type: 'text', value: ':'}
         ]
       },


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

When using this utility, the directive types will automatically be added
to mdast in the correct places.
See DefinitelyTyped/DefinitelyTyped#54421 for more information.

<!--do not edit: pr-->
